### PR TITLE
Proposed fix for Issue #32: Readme tab gives NameError with Redmine 2.1.4

### DIFF
--- a/app/controllers/digest_controller.rb
+++ b/app/controllers/digest_controller.rb
@@ -18,6 +18,8 @@
 if Rails::VERSION::MAJOR < 3
 	require 'rdoc/markup/simple_markup'
 	require 'rdoc/markup/simple_markup/to_html'
+else
+	require 'rdoc'
 end
 
 class DigestController < ApplicationController


### PR DESCRIPTION
This simple patch fixed the problem for me.
