### PR TITLE
fixed German umlauts and minor typos

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,30 +1,30 @@
 de:
 # German strings go here
-  label_digest_account_settings: Bericht zu den Projektaktivit�ten
-  label_digest_account_description: Aboniere den periodischen Email Versand eines Berichts zu den Projektaktivit�ten.
+  label_digest_account_settings: Bericht zu Projektaktivitäten
+  label_digest_account_description: Abonniere den periodischen Email Versand eines Berichts zu den Projektaktivitäten.
   label_digest_account_enabled: Send me digest emails
   label_digest_default_account_enabled: Standardbenutzereinstellung
   label_active: Aktiv
   
-  mail_body_digest: "[%{project}] Aktivit�ten: %{count} Ereignisse"
-  mail_subject_digest: "[%{project}] Aktivit�ten: %{count} Ereignisse"
+  mail_body_digest: "[%{project}] Aktivitäten: %{count} Ereignisse"
+  mail_subject_digest: "[%{project}] Aktivitäten: %{count} Ereignisse"
   
-  digest_days: Anzahl der Tage f�r den Bericht
-  digest_start: Starte mit der Erfassung der Aktivit�ten vor x Tagen
+  digest_days: Anzahl der Tage für den Bericht
+  digest_start: Starte mit der Erfassung der Aktivitäten vor x Tagen
   start_explanation: 0 = ab heute, 1 = ab gestern, 7 = vor einer Woche 
   days: "Tag(e)"
-  label_activity_view_all: alle Aktivit�ten anzeigen
+  label_activity_view_all: alle Aktivitäten anzeigen
   label_example: Beispiele
   label_note: Notizen
-  label_note_text: Der Zeitplanungsprogramm f�r den  'rake task' �berschreibt diese Standardeinstelklungen falls die Parameter explizit im Aufruf gesetzt werden.
-  label_example_text: Das Kapitel Benutzerhinweise und Beispiele der  'Readme' beschreibt einige praktikable Strategien.
+  label_note_text: Das Zeitplanungsprogramm für den 'rake task' überschreibt diese Standardeinstellungen falls die Parameter explizit im Aufruf gesetzt werden.
+  label_example_text: Das Kapitel Benutzerhinweise und Beispiele der 'Readme' beschreibt einige praktikable Strategien.
   label_send_test_email: Verschicke eine Test-Mail an deine Email Adresse.
-  label_send_all_digests: Verschicke Berichte f�r alle Projekte mit aktivem Abo
-  label_apply_changes_first: Bitte speichern Sie ihre Einstellungen vor dem Mail Versand damit diese ber�cksichtigt werden.
+  label_send_all_digests: Verschicke Berichte für alle Projekte mit aktivem Abo
+  label_apply_changes_first: Bitte speichern Sie Ihre Einstellungen vor dem Mail Versand damit diese berücksichtigt werden.
   label_output_extra_messages: Output extra messages (console and log)
   
   notice_digest_sent_to: "Ein Bericht wurde versendet: %{value}."
   notice_digests_sent: Die Mails mit dem Bericht wurden versendet.
-  notice_digest_error: "W�hrend des Versands ist ein Fehler aufgetreten (%{value})"
+  notice_digest_error: "Während des Versands ist ein Fehler aufgetreten (%{value})"
 
-  field_active: Aboniere den periodischen Email Versand eines Berichts zu den Projektaktivit�ten.
+  field_active: Abonniere den periodischen Email-Versand eines Berichts zu den Projektaktivitäten.


### PR DESCRIPTION
German umlauts in localized strings were broken; replaced with correct ones. Minor cosmetic typo corrections. Tested on Redmine 2.1.4.stable
