### PR TITLE
Adds support for user groups

### DIFF
--- a/app/models/digest_mailer.rb
+++ b/app/models/digest_mailer.rb
@@ -161,8 +161,15 @@ class DigestMailer < Mailer
 		default = Setting.plugin_redmine_digest[:default_account_enabled]
 		default = default.nil? ? true : default
 		dbg "Default setting for whether digest is active for users: %s" % default.to_s
-		members = Member.find(:all, :conditions => ["project_id = " + project[:id].to_s]).each { |m|
+
+		members = Member.find(:all, :conditions => { :project_id => project[:id] }).each { |m|
 			user = m.user
+
+			# Skip groups
+			if user.nil?
+				next
+			end
+
 			puts "Found user %s" % user.id
 			if user && user.active? && user.mail
 				if user.digest_account.nil?


### PR DESCRIPTION
In order to have the digest_mailer work correctly when using user groups in redmine, we need to skip groups.
As Member.find returns all users, groups, and users within all groups, this should not be a problem.

Works at least fine here.
